### PR TITLE
Modificaciones en los métodos del grafo de la clase Cargador

### DIFF
--- a/Cargador.cpp
+++ b/Cargador.cpp
@@ -3,7 +3,7 @@
 
     /// METODOS PRIVADOS ///
 
-void Cargador::cargarDatos(Diccionario<string,Aeropuerto*> *&arbolAeropuertos, const string& ruta)
+void Cargador::cargarDatos(Diccionario<string, Aeropuerto*> *&arbolAeropuertos, const string& ruta)
 {
     ifstream archivo;
     archivo.open(ruta.c_str(),ios::in);
@@ -13,7 +13,7 @@ void Cargador::cargarDatos(Diccionario<string,Aeropuerto*> *&arbolAeropuertos, c
             throw (Excepcion(EXCEPCION_ABB));
 
         cargadorDeDiccionario(arbolAeropuertos, archivo);
-        cout << "\n\tSe han cargado los Aeropuertos en el arbol correctamente\n";
+        cout << "\n\tSe han cargado los aeropuertos en el arbol correctamente\n";
     }
     catch(Excepcion &e) {
         cout << e.what() << endl;
@@ -21,8 +21,8 @@ void Cargador::cargarDatos(Diccionario<string,Aeropuerto*> *&arbolAeropuertos, c
 
     archivo.close();
 }
-/*
-void Cargador::cargarDatos(Grafo<Vuelo*> &grafoVuelos, string ruta)
+
+void Cargador::cargarDatos(Grafo *&grafoVuelos, string ruta)
 {
     ifstream archivo;
     archivo.open(ruta.c_str(),ios::in);
@@ -32,7 +32,7 @@ void Cargador::cargarDatos(Grafo<Vuelo*> &grafoVuelos, string ruta)
             throw (Excepcion(EXCEPCION_GRAFO));
 
         cargadorDeGrafo(grafoVuelos, archivo);
-        cout << "\n\tSe han cargado los vuelos en el arbol correctamente\n";
+        cout << "\n\tSe han cargado los vuelos en el grafo correctamente\n";
     }
 
     catch(Excepcion &e) {
@@ -41,10 +41,10 @@ void Cargador::cargarDatos(Grafo<Vuelo*> &grafoVuelos, string ruta)
 
     archivo.close();
 }
-*/
+
     /// METODOS PUBLICOS ///
 
-void Cargador::cargadorDeDiccionario(Diccionario<string ,Aeropuerto*> *&arbolAeropuertos, ifstream& archivo)
+void Cargador::cargadorDeDiccionario(Diccionario<string, Aeropuerto*> *&arbolAeropuertos, ifstream& archivo)
 {
     string nombre, ciudad, pais, codigoIATA;
     double superficie;
@@ -67,13 +67,23 @@ void Cargador::cargadorDeDiccionario(Diccionario<string ,Aeropuerto*> *&arbolAer
                                      pais, superficie, cantidadTerminales,
                                      destinosNacionales, destinosInternacionales);
 
-
         arbolAeropuertos->insertar(codigoIATA,pAeropuerto);
     }
 
 }
-/*
-void Cargador:: cargadorDeGrafo(int &grafo, ifstream &archivo) {
-    //TODO
+
+void Cargador:: cargadorDeGrafo(Grafo *&grafoVuelos, ifstream &archivo)
+{
+    string origen, destino;
+    int precio;
+    float horas;
+
+    while(!archivo.eof()) {
+        archivo >> origen;
+        archivo >> destino;
+        archivo >> precio;
+        archivo >> horas;
+        grafoVuelos->agregarArista(origen, destino, precio, horas);
+    }
 }
-*/
+

--- a/Cargador.h
+++ b/Cargador.h
@@ -2,10 +2,11 @@
 #define CARGADOR_H
 
 //Librerias de C++
-#include<fstream>
+#include <fstream>
 
 //Librerias locales
 #include "Diccionario.h"
+#include "Grafo.h"
 #include "Aeropuerto.h"
 #include "Excepcion.h"
 
@@ -18,22 +19,22 @@ using namespace std;
 class Cargador
 {
     private:
-        //PRE : ABB , archivo ya abierto
-        //POST:carga los datos en el arbol binario de busqueda
-        void cargadorDeDiccionario(Diccionario<string ,Aeropuerto*> *&arbolAeropuertos, ifstream &archivo);
+        //PRE : -
+        //POST: Carga los datos del archivo en el diccionario
+        void cargadorDeDiccionario(Diccionario<string, Aeropuerto*> *&arbolAeropuertos, ifstream &archivo);
 
-        //PRE: Grafo , archivo ya abierto
-        //POST: carga los datos en el grafo
-        //void cargadorDeGrafo(Grafo<Vuelo*> &grafoVuelos , ifstream &archivo);
+        //PRE : -
+        //POST: Carga los datos del archivo en el grafo
+        void cargadorDeGrafo(Grafo *&grafoVuelos, ifstream &archivo);
 
     public:
-        //PRE : Objeto Arbol, ruta al archivo
-        //POST: Abre el archivo y carga los datos , de fallar se ejecuta la excepcion
-        void cargarDatos(Diccionario<string ,Aeropuerto*> *&arbolAeropuertos, const string& ruta);
+        //PRE : El string es la ruta al archivo
+        //POST: Abre el archivo y carga los datos, de fallar se lanza la excepcion
+        void cargarDatos(Diccionario<string, Aeropuerto*> *&arbolAeropuertos, const string& ruta);
 
-        //PRE :Objeto Grafo, ruta al archivo
-        //POST:Abre el archivo y carga los datos , de fallar se ejecuta la excepcion
-        //void cargarDatos(Grafo<Vuelo*> &grafoVuelos,string ruta);
+        //PRE : El string es la ruta al archivo
+        //POST: Abre el archivo y carga los datos, de fallar se lanza la excepcion
+        void cargarDatos(Grafo *&grafoVuelos, const string& ruta);
 };
 
 #endif /*CARGADOR_H*/


### PR DESCRIPTION
- Incluí el header "Grafo.h"
- Descomente los métodos relacionados al grafo
- Modifique las pre-condiciones basandome en algo que dijo Nico en una de las ultimas clases que tuvimos. 
Básicamente poner como pre-condición "El string es un string o el ABB es un ABB" no es una pre-condición valida, porque en el caso de que no sea un string o un ABB el programa directamente no compila
- Corregí la parte del template del grafo (decia Grafo<Vuelo*> pero al final lo hicimos sin)
- Lo que reciben los métodos ahora son punteros por referencia (antes se recibía el grafo por referencia, no el puntero al grafo)